### PR TITLE
Integration of android CustomTabsService

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ description: Open an in-app browser window.
 * closebuttonicon: (relative path string) path to icon to use as close button
 * statusbarstyle: (light or dark) defines status bar font color
 * shadowsize: (number) Android only, defines shadow below toolbar. On iOS, shadow looks always the same.
+#### Android only options
+* useCustomTabs: (string) defines if customTabs (default Google Chrome) shall be used as alternative browser. Accepted params "yes" or "no".
+* hideURLBar: (string) defines if the URL-bar shall be hidden during scrolling. Accepted params "yes" or "no".
+* shareState: (int) defines if the share-option shall be visible. Value "0" sets the share-option according to the default setting of the used browser. Value "1" explicitly enables the share-option. Value "2" disables the share-option.
 
 # cordova-plugin-inappbrowser
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,10 +44,20 @@
                 <param name="android-package" value="org.apache.cordova.inappbrowser.InAppBrowser"/>
             </feature>
         </config-file>
+        <config-file target="AndroidManifest.xml" parent="/manifest">
+            <queries>
+               <intent>
+                   <action android:name="android.support.customtabs.action.CustomTabsService" />
+               </intent>
+            </queries>
+        </config-file>
+
+        <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
 
         <source-file src="src/android/InAppBrowser.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppBrowserDialog.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppChromeClient.java" target-dir="src/org/apache/cordova/inappbrowser" />
+        <source-file src="src/android/CustomTabs.java" target-dir="src/org/apache/cordova/inappbrowser" />
 
         <!-- drawable src/android/resources -->
         <resource-file src="src/android/res/drawable-hdpi/ic_action_next_item.png" target="res/drawable-hdpi/ic_action_next_item.png" />

--- a/src/android/CustomTabs.java
+++ b/src/android/CustomTabs.java
@@ -1,0 +1,87 @@
+package org.apache.cordova.inappbrowser;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+
+import androidx.browser.customtabs.CustomTabsIntent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static androidx.browser.customtabs.CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION;
+
+public class CustomTabs {
+    /**
+     * Reference for the Google Chrome application package
+     */
+    private static final String CHROME_PACKAGE_NAME = "com.android.chrome";
+
+    /**
+     * Checks all available application packages, which are able to handle view intents. If Google Chrome is installed, this application will be used as prefered option.
+     * All customaziable UI Elements get set within this function.
+     * @param context
+     * @param url
+     * @param toolbarColor
+     * @param closeButton
+     * @param showTitle
+     * @param hideUrlBar
+     * @param shareState
+     * @return
+     */
+    public static boolean openWebBrowser(Context context, String url, int toolbarColor, Bitmap closeButton, boolean showTitle, boolean hideUrlBar, int shareState) {
+      List<String> packageNames = getCustomTabsPackages(context);
+
+      if (packageNames.size() > 0) {
+          CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+          builder.setToolbarColor(toolbarColor);
+          builder.setUrlBarHidingEnabled(hideUrlBar);
+          builder.setShareState(shareState);
+          builder.setShowTitle(showTitle);
+          if (closeButton != null) {
+              builder.setCloseButtonIcon(closeButton);
+          }
+          Intent intent = new Intent(Intent.ACTION_SEND);
+          intent.setType("text/plain");
+          intent.putExtra(Intent.EXTRA_TEXT, url);
+          CustomTabsIntent customTabsIntent = builder.build();
+          if (packageNames.contains(CHROME_PACKAGE_NAME)) {
+              customTabsIntent.intent.setPackage(CHROME_PACKAGE_NAME);
+          }
+          customTabsIntent.launchUrl(context, Uri.parse(url));
+          return true;
+      }
+      return false;
+    }
+
+    /**
+     * Returns a list of packages that support handling of view intents.
+     */
+    private static List<String> getCustomTabsPackages(Context context) {
+
+        PackageManager pm = context.getPackageManager();
+        // Get default VIEW intent handler.
+        Intent activityIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+
+        // Get all apps that can handle VIEW intents.
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
+        List<String> packagesSupportingCustomTabs = new ArrayList<>();
+        for (ResolveInfo info : resolvedActivityList) {
+            Intent serviceIntent = new Intent();
+            serviceIntent.setAction(ACTION_CUSTOM_TABS_CONNECTION);
+            String packageName = info.activityInfo.packageName;
+            serviceIntent.setPackage(packageName);
+            // Check if this package also resolves the Custom Tabs service.
+            if (pm.resolveService(serviceIntent, 0) != null) {
+                packagesSupportingCustomTabs.add(packageName);
+            }
+        }
+        return packagesSupportingCustomTabs;
+    }
+
+}

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation "androidx.browser:browser:1.3.0"
+}


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
Android WebView does not support downloading or reading PDF-files based on the missing integration.
Change is required to allow a full functional browser providing e. g. PDF-Download function.

### Description
This change integrates the android CustomTabsService as an optional in-app-browser functionality.
In case the used platform dos not provide any installed application packages, which can handle view-intents, the default android WebView will be used, based on the original cordova-plugin-inappbrowser.

### Testing
Tested on android device and android emulator using VS Code and Android Studio for developing.
